### PR TITLE
Fix topics notifications

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { StatusBar } from '@ionic-native/status-bar/ngx';
 import { SplashComponent } from './components/splash/splash.component';
 import { Router } from '@angular/router';
 import { AudioService } from './services/audio.service';
+import { NotificationsService } from './services/notifications.service';
 
 @Component({
   selector: 'app-root',
@@ -20,7 +21,8 @@ export class AppComponent
     private statusBar: StatusBar,
     private modalCtrl: ModalController,
     private router: Router,
-    private audioService: AudioService
+    private audioService: AudioService,
+    private notificationService:NotificationsService
   )
   {
 
@@ -39,6 +41,7 @@ export class AppComponent
   {
     this.platform.ready().then(() =>
     {
+      this.notificationService.unsubscribeAll();
       this.statusBar.styleDefault();
       this.splashScreen.hide();
     });

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -37,7 +37,8 @@ export class HomePage implements OnInit
     private productoService: ProductoService,
     private modalController: ModalController,
     private UIVisual: UIVisualService,
-    private encuestaService: EncuestaService
+    private encuestaService: EncuestaService,
+    private notificationService:NotificationsService
   ) { }
 
   ngOnInit()
@@ -53,6 +54,7 @@ export class HomePage implements OnInit
 
   cerrarSesion()
   {
+    this.notificationService.unsubscribeAll();
     this.authService.onLogout();
     this.router.navigate(['/auth-page']);
   }

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -115,6 +115,26 @@ export class NotificationsService
       .catch((err) => console.error(err));
   }
 
+  unsubscribeAll()
+  {
+    fcm
+      .unsubscribeFrom({ topic: 'jefes' })
+      .then((r) => console.log(`unsubcribed from jefes`))
+      .catch((err) => console.error(err));
+    fcm
+      .unsubscribeFrom({ topic: 'mozos' })
+      .then((r) => console.log(`unsubcribed from mozos`))
+      .catch((err) => console.error(err));
+    fcm
+      .unsubscribeFrom({ topic: 'cocineros' })
+      .then((r) => console.log(`unsubcribed from cocineros`))
+      .catch((err) => console.error(err));
+    fcm
+      .unsubscribeFrom({ topic: 'bartenders' })
+      .then((r) => console.log(`unsubcribed from bartenders`))
+      .catch((err) => console.error(err));
+  }
+
   /**
    * Funcion booleana para saber si un usuario ya tiene un token registrado
    * @param usuario 


### PR DESCRIPTION
Cuando un dispositivo se subscribe a un tema se debe desubscribir en algún momento sino se acumulan las subscripciones.
Ahora al iniciar la aplicación se desubscribe de todos los topis y al hacer logout también.